### PR TITLE
pas de série "I" si doubleGauge=false

### DIFF
--- a/json.php
+++ b/json.php
@@ -125,7 +125,10 @@ function instantly () {
         $val["W"] = floatval(str_replace(",", ".", $row["PAPP"]));
         $val["I"] = floatval(str_replace(",", ".", $row["IINST1"]));
         $series["W"] = "Watts";
-        $series["I"] = "Ampères";
+        // Double Gauge ?
+        if ($graphConf["doubleGauge"]) {
+            $series["I"] = "Ampères";
+	}
 
         $query = queryMaxPeriod ($timestampdebut2, $timestampfin, $optarif);
         $result=$mysqli->query($query);


### PR DESCRIPTION
si on ne veut pas afficher la double gauge Watt / Ampère, il ne faut pas mettre la série "I" dans la réponse json, sinon erreur javascript...

même modif en branche master et dev
